### PR TITLE
Cleanup and suggestions

### DIFF
--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/jackson/GuiceJacksonHandlerInstantiator.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/jackson/GuiceJacksonHandlerInstantiator.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
 import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
+import com.fasterxml.jackson.databind.util.Converter;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 
@@ -22,6 +23,12 @@ public class GuiceJacksonHandlerInstantiator extends HandlerInstantiator {
     @Inject
     public GuiceJacksonHandlerInstantiator(final Injector injector) {
         this.injector = injector;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Converter<?, ?> converterInstance(final MapperConfig<?> config, final Annotated annotated, final Class<?> implClass) {
+        return injector.getInstance((Class<? extends Converter>) implClass);
     }
 
     @SuppressWarnings("unchecked")

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/jackson/OperationTypeToStringConverter.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/jackson/OperationTypeToStringConverter.java
@@ -1,0 +1,16 @@
+package com.instaclustr.sidecar.jackson;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+import com.instaclustr.sidecar.operations.OperationType;
+
+public class OperationTypeToStringConverter extends StdConverter<OperationType, String> {
+
+    @Override
+    public String convert(final OperationType value) {
+        if (value == null) {
+            return null;
+        }
+
+        return value.toString().toLowerCase();
+    }
+}

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/jackson/StringToOperationTypeConverter.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/jackson/StringToOperationTypeConverter.java
@@ -1,0 +1,27 @@
+package com.instaclustr.sidecar.jackson;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+import com.instaclustr.sidecar.operations.OperationType;
+
+public class StringToOperationTypeConverter extends StdConverter<String, OperationType> {
+
+    private final Map<String, OperationType> stringOperationTypeMap;
+
+    @Inject
+    public StringToOperationTypeConverter(final Map<String, OperationType> stringOperationTypeMap) {
+        this.stringOperationTypeMap = stringOperationTypeMap;
+    }
+
+    @Override
+    public OperationType convert(final String value) {
+        if (value == null) {
+            return null;
+        }
+
+        return Optional.ofNullable(stringOperationTypeMap.get(value.toLowerCase())).orElse(OperationType.UNKNOWN);
+    }
+}

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/Operation.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/Operation.java
@@ -2,7 +2,9 @@ package com.instaclustr.sidecar.operations;
 
 import javax.inject.Inject;
 import java.time.Instant;
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -28,7 +30,13 @@ public abstract class Operation<RequestT extends OperationRequest> implements Ru
     }
 
     public enum State {
-        PENDING, RUNNING, COMPLETED, FAILED
+        PENDING, RUNNING, COMPLETED, FAILED;
+
+        public static Set<State> TERMINAL_STATES = EnumSet.of(COMPLETED, FAILED);
+
+        public boolean isTerminalState() {
+            return TERMINAL_STATES.contains(this);
+        }
     }
 
     public final UUID id = UUID.randomUUID();

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationBindings.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationBindings.java
@@ -32,6 +32,7 @@ public final class OperationBindings {
 
         final TypeLiteral<Class<? extends OperationRequest>> operationRequestClassType = new TypeLiteral<Class<? extends OperationRequest>>() {};
         final TypeLiteral<Class<? extends Operation>> operationClassType = new TypeLiteral<Class<? extends Operation>>() {};
+        final TypeLiteral<OperationType> operationTypeTypeLiteral = new TypeLiteral<OperationType>(){};
 
         // get Guice to create the AssistedInject OperationFactory implementation for the Operation class
         // to allow creation Operations from their OperationRequests
@@ -52,5 +53,10 @@ public final class OperationBindings {
         // this allows Operation.TypeIdResolver to lookup the Class for a given typeId (and vice versa)
         MapBinder.newMapBinder(binder, TypeLiteral.get(OperationType.class), operationClassType)
                 .addBinding(typeId).toInstance(operationClass);
+
+        // add an entry to the Map<String, OperationType> for the typeId.
+        // this allows StringToOperationTypeConverter to lookup the OperationType for a given typeId
+        MapBinder.newMapBinder(binder, TypeLiteral.get(String.class), operationTypeTypeLiteral)
+                .addBinding(typeId.toString().toLowerCase()).toInstance(typeId);
     }
 }

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationRequest.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationRequest.java
@@ -3,8 +3,8 @@ package com.instaclustr.sidecar.operations;
 import javax.inject.Inject;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.instaclustr.sidecar.jackson.MapBackedTypeIdResolver;
@@ -14,7 +14,7 @@ import com.instaclustr.sidecar.jackson.MapBackedTypeIdResolver;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class OperationRequest {
 
-    @JsonProperty("type")
+    @JsonIgnore
     public OperationType type;
 
     static class TypeIdResolver extends MapBackedTypeIdResolver<OperationRequest> {

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationType.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationType.java
@@ -3,4 +3,11 @@ package com.instaclustr.sidecar.operations;
 public interface OperationType {
 
     String toString();
+
+    static final OperationType UNKNOWN = new OperationType() {
+        @Override
+        public String toString() {
+            return "UNKNOWN";
+        }
+    };
 }

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationsFilter.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationsFilter.java
@@ -1,0 +1,35 @@
+package com.instaclustr.sidecar.operations;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.MoreObjects;
+import com.instaclustr.sidecar.jackson.OperationTypeToStringConverter;
+import com.instaclustr.sidecar.jackson.StringToOperationTypeConverter;
+import com.instaclustr.sidecar.validation.Enum;
+
+public class OperationsFilter {
+
+    @JsonSerialize(converter = OperationTypeToStringConverter.class)
+    @JsonDeserialize(converter = StringToOperationTypeConverter.class)
+    public final OperationType type;
+
+    @Enum(enumClass = Operation.State.class, ignoreCase = true)
+    public final String state;
+
+    @JsonCreator
+    public OperationsFilter(final @JsonProperty("type") OperationType type,
+                            final @JsonProperty("state") String state) {
+        this.type = type;
+        this.state = state;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("type", type)
+                .add("state", state)
+                .toString();
+    }
+}

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationsResource.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationsResource.java
@@ -47,6 +47,12 @@ public class OperationsResource {
     }
 
     @POST
+    @Path("filter")
+    public Collection<Operation> operations(@Valid @NotNull OperationsFilter operationsFilter) {
+        return operationsService.operations(operationsFilter);
+    }
+
+    @POST
     public Response createNewOperation(@Valid final OperationRequest request) {
         final Operation operation = operationsService.submitOperationRequest(request);
 

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationsService.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/operations/OperationsService.java
@@ -1,6 +1,9 @@
 package com.instaclustr.sidecar.operations;
 
+import static java.util.stream.Collectors.toList;
+
 import javax.inject.Inject;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -58,5 +61,39 @@ public class OperationsService extends AbstractIdleService {
 
     public Optional<Operation> operation(final UUID id) {
         return Optional.ofNullable(operations.get(id));
+    }
+
+    public Collection<Operation> operations(final OperationsFilter operationsFilter) {
+        final Collection<Operation> operations = operationsByType(operationsFilter.type);
+
+        if (operationsFilter.state != null) {
+            return operationsByState(operations, Operation.State.valueOf(operationsFilter.state.toUpperCase()));
+        }
+
+        return operations;
+    }
+
+    private Collection<Operation> operationsByType(final OperationType operationType) {
+        return operationsByType(Collections.unmodifiableCollection(operations.values()), operationType);
+    }
+
+    private Collection<Operation> operationsByState(final Operation.State state) {
+        return operationsByState(Collections.unmodifiableCollection(operations.values()), state);
+    }
+
+    private Collection<Operation> operationsByState(final Collection<Operation> operations, final Operation.State state) {
+        if (state == null) {
+            return Collections.unmodifiableCollection(operations);
+        }
+
+        return operations.stream().filter(entry -> entry.state == state).collect(toList());
+    }
+
+    private Collection<Operation> operationsByType(final Collection<Operation> operations, final OperationType operationType) {
+        if (operationType == null) {
+            return Collections.unmodifiableCollection(operations);
+        }
+
+        return Collections.unmodifiableCollection(operations.stream().filter(entry -> entry.request.type.getClass() == operationType.getClass()).collect(toList()));
     }
 }

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/validation/Enum.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/validation/Enum.java
@@ -1,0 +1,28 @@
+package com.instaclustr.sidecar.validation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = {EnumValidator.class})
+@Target({METHOD, FIELD, PARAMETER})
+@Retention(RUNTIME)
+public @interface Enum {
+    String message() default "Invalid value. This is not permitted.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends java.lang.Enum<?>> enumClass();
+
+    boolean ignoreCase() default false;
+}

--- a/java/sidecar-common/src/main/java/com/instaclustr/sidecar/validation/EnumValidator.java
+++ b/java/sidecar-common/src/main/java/com/instaclustr/sidecar/validation/EnumValidator.java
@@ -1,0 +1,47 @@
+package com.instaclustr.sidecar.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class EnumValidator implements ConstraintValidator<Enum, String> {
+
+    private Enum annotation;
+
+    @Override
+    public void initialize(final Enum annotation) {
+        this.annotation = annotation;
+    }
+
+    @Override
+    public boolean isValid(final String value, final ConstraintValidatorContext context) {
+
+        context.disableDefaultConstraintViolation();
+
+        if (value == null) {
+            return true;
+        }
+
+        final Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+
+        if (enumValues != null) {
+            for (final Object enumValue : enumValues) {
+                if (value.equals(enumValue.toString()) || (this.annotation.ignoreCase() && value.equalsIgnoreCase(enumValue.toString()))) {
+                    return true;
+                }
+            }
+        }
+
+        if (enumValues != null) {
+            final String message = String.format("Value '%s' is invalid for enumeration %s. Possible values: %s",
+                                                 value,
+                                                 this.annotation.enumClass(),
+                                                 Arrays.stream(enumValues).map(Object::toString).collect(Collectors.joining(",")));
+
+            context.buildConstraintViolationWithTemplate(message).addConstraintViolation();
+        }
+
+        return false;
+    }
+}

--- a/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/backup/BackupOperationRequest.java
+++ b/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/backup/BackupOperationRequest.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.instaclustr.cassandra.sidecar.operations.CassandraOperationType;
 import com.instaclustr.sidecar.operations.OperationRequest;
 
 @SuppressWarnings("WeakerAccess")
@@ -21,6 +22,7 @@ public class BackupOperationRequest extends OperationRequest {
         this.destinationUri = destinationUri;
         this.snapshotName = snapshotName;
         this.keyspaces = keyspaces;
+        this.type = CassandraOperationType.BACKUP;
     }
 
     @Override

--- a/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/cleanup/CleanupOperationRequest.java
+++ b/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/cleanup/CleanupOperationRequest.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.instaclustr.cassandra.sidecar.operations.CassandraOperationType;
 import com.instaclustr.sidecar.operations.OperationRequest;
 
 /**
@@ -67,6 +68,7 @@ public class CleanupOperationRequest extends OperationRequest {
         this.jobs = jobs;
         this.keyspace = keyspace;
         this.tables = tables;
+        this.type = CassandraOperationType.CLEANUP;
     }
 
     @Override

--- a/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/decommission/DecommissionOperationRequest.java
+++ b/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/decommission/DecommissionOperationRequest.java
@@ -2,10 +2,15 @@ package com.instaclustr.cassandra.sidecar.operations.decommission;
 
 
 import com.google.common.base.MoreObjects;
+import com.instaclustr.cassandra.sidecar.operations.CassandraOperationType;
 import com.instaclustr.sidecar.operations.OperationRequest;
 
 public class DecommissionOperationRequest extends OperationRequest {
     // decommission requests have no parameters
+
+    public DecommissionOperationRequest() {
+        this.type = CassandraOperationType.DECOMMISSION;
+    }
 
     @Override
     public String toString() {

--- a/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/rebuild/RebuildOperationRequest.java
+++ b/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/rebuild/RebuildOperationRequest.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.instaclustr.cassandra.sidecar.operations.CassandraOperationType;
 import com.instaclustr.cassandra.sidecar.operations.upgradesstables.ValidRebuildOperationRequest;
 import com.instaclustr.sidecar.operations.OperationRequest;
 
@@ -78,6 +79,7 @@ public class RebuildOperationRequest extends OperationRequest {
         this.keyspace = keyspace;
         this.specificTokens = specificTokens;
         this.specificSources = specificSources;
+        this.type = CassandraOperationType.REBUILD;
     }
 
     public static final class TokenRange {

--- a/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/scrub/ScrubOperationRequest.java
+++ b/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/scrub/ScrubOperationRequest.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.instaclustr.cassandra.sidecar.operations.CassandraOperationType;
 import com.instaclustr.sidecar.operations.OperationRequest;
 
 /**
@@ -101,6 +102,7 @@ public class ScrubOperationRequest extends OperationRequest {
         this.skipCorrupted = skipCorrupted;
         this.noValidate = noValidate;
         this.reinsertOverflowedTTL = reinsertOverflowedTTL;
+        this.type = CassandraOperationType.SCRUB;
     }
 
     @Override

--- a/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/upgradesstables/UpgradeSSTablesOperationRequest.java
+++ b/java/sidecar/src/main/java/com/instaclustr/cassandra/sidecar/operations/upgradesstables/UpgradeSSTablesOperationRequest.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.instaclustr.cassandra.sidecar.operations.CassandraOperationType;
 import com.instaclustr.sidecar.operations.OperationRequest;
 
 /**
@@ -77,6 +78,7 @@ public class UpgradeSSTablesOperationRequest extends OperationRequest {
         this.keyspace = keyspace;
         this.tables = tables;
         this.includeAllSSTables = includeAllSSTables;
+        this.type = CassandraOperationType.UPGRADESSTABLES;
     }
 
     @Override


### PR DESCRIPTION
- Switch to using an iterator over the value set of the operations map, and then just calling remove.
 This avoids creating a new set, and the whole stream-filter-collet song and dance.

- Add `isTerminalState` to `Operation.State` enum, to make it easier to filter based on "completed" operations.